### PR TITLE
Fix for raw output

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -169,6 +169,9 @@ async function writeFile(
       console.log(`Source parser ${sourceParser.title} does not support the following properties:`);
       console.log(readUnsupportedProperties);
     }
+
+    let output = '';
+    
     if (readOutput) {
       indicator.text = `Writing to ${targetFile}`;
       if (targetParser) {
@@ -188,13 +191,17 @@ async function writeFile(
           console.log(`Target parser ${targetParser.title} does not support the following properties:`);
           console.log(writeUnsupportedProperties);
         }
-        if (targetFile) {
-          await promises.writeFile(targetFile, writeOutput, 'utf-8');
-          indicator.succeed(`File "${sourceFile}" translated successfully. Output written to ${targetFile}`);
-        } else {
-          indicator.succeed(`File "${sourceFile}" translated successfully. Output written to stdout:\n`);
-          console.log(writeOutput);
-        }
+        output = writeOutput;
+      }
+
+      output = output ? output :JSON.stringify(readOutput);
+
+      if (targetFile) {
+        await promises.writeFile(targetFile, output, 'utf-8');
+        indicator.succeed(`File "${sourceFile}" translated successfully. Output written to ${targetFile}`);
+      } else {
+        indicator.succeed(`File "${sourceFile}" translated successfully. Output written to stdout:\n`);
+        console.log(output);
       }
     }
   } catch (error) {


### PR DESCRIPTION
Hacky update just to show the issue - raw output is no longer supported without this change e.g. `npm start -- -s sld -t geostyler -o C:/Temp C:\Temp/itasca.sld` as the code expects a `targetParser`. 
I couldn't see an easy way to use a `const` variable without more code changes. 